### PR TITLE
Make pre-commit lint-only

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "check": "npm run audit && npm run deps && npm outdated --depth 0"
   },
   "pre-commit": [
-    "check"
+    "lint"
   ],
   "devDependencies": {
     "babel": "^5.5.8",


### PR DESCRIPTION
In the interest of staying out of the way of devs who commit often, make the pre-commit hook lint-only.