### PR TITLE
Add webpack minimal build, fixes #16

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "clean": "rimraf build",
     "lint": "eslint source && eslint test",
     "prebuild": "npm run clean",
-    "build": "babel -d build source -s",
+    "build": "NODE_ENV=production webpack",
+    "start": "webpack --watch",
     "test": "babel-node test/index.js",
     "cov": "npm run cov:clean && npm run cov:generate",
     "cov:clean": "rimraf coverage",
@@ -30,13 +31,18 @@
   "devDependencies": {
     "babel": "^5.5.8",
     "babel-eslint": "^3.1.15",
+    "babel-loader": "^5.1.4",
+    "babel-plugin-object-assign": "^1.1.0",
     "dependency-check": "^2.4.0",
     "eslint": "^0.23.0",
+    "eslint-loader": "^0.14.0",
     "faucet": "0.0.1",
     "isparta": "^3.0.3",
+    "node-libs-browser": "^0.5.2",
     "nsp": "^1.0.1",
     "precommit-hook": "^3.0.0",
     "rimraf": "^2.4.0",
-    "tape": "^4.0.0"
+    "tape": "^4.0.0",
+    "webpack": "^1.9.11"
   }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,0 +1,55 @@
+var webpack = require('webpack');
+var path = require('path');
+var env = process.env.NODE_ENV || 'development';
+
+
+var eslintLoader = {
+  test: /\.js$/,
+  loaders: ['eslint'],
+  include: path.resolve('./source')
+};
+
+
+module.exports = {
+  devtool: 'sourcemap',
+
+  entry: './source/index.js',
+
+  output: {
+    filename: 'index.js',
+    path: path.resolve('./build')
+  },
+
+  plugins: [
+    new webpack.DefinePlugin({
+      'process.env': {
+        NODE_ENV: '"' + env + '"'
+      }
+    })
+  ],
+
+  module: {
+    preLoaders: env === 'development' ? [
+      eslintLoader
+    ] : [],
+    loaders: [
+      {
+        test: /\.js$/,
+        loaders: ['babel?plugins=object-assign'],
+        include: path.resolve('./source')
+      }
+    ]
+  },
+
+  resolve: {
+    extensions: ['', '.js']
+  },
+
+  stats: {
+    colors: true
+  },
+
+  eslint: {
+    configFile: './.eslintrc'
+  }
+};


### PR DESCRIPTION
Does not include build for tests, any html output and any kind of css/style/assets loaders. Just a bare minimum to replace babel-only build.

Some extras:
1. `process.env.NODE_ENV` env variable for built code (for example, React skips PropType validation in `production`)
2. `npm start` will run webpack in watch mode (incremental builds) in `development` mode
3. ESLint loader is added in `development`, so we can get compile-time linting (try with `npm start`)

![webpack](https://cloud.githubusercontent.com/assets/175264/8304834/d66f7944-19ec-11e5-9feb-9f66caa5c593.gif)
