### PR TITLE
Fix `npm run lint` script

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "init": "rimraf .validate.json && rimraf .jshintrc",
     "clean": "rimraf build",
-    "lint": "eslint source && eslint test",
+    "lint": "eslint source test",
     "prebuild": "npm run clean",
     "build": "NODE_ENV=production webpack && npm run build:min",
     "build:min": "NODE_ENV=production MINIFY=1 webpack",


### PR DESCRIPTION
First eslint was run from node_modules, but the second one from global npm. I kept getting errors `babel-eslint not found` because I did not have it installed globally.

Anyway eslint is smart enough to handle multiple folders/files